### PR TITLE
Tidy up RdCore Installation with docker

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+RADIUSDESK_VOLUME=./data/radiusdesk
+RADIUSDESK_NETWORK=radiusdesk-bridge

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,14 @@ FROM jtreminio/php:8.1
     RUN apt-get install -y subversion 
 
     # Prepare all directories
-    COPY ./default /etc/nginx/sites-enabled/
-    COPY ./disable_strict_mode.cnf /etc/mysql/conf.d/
-    COPY ./rdcore /var/www/rdcore
+    COPY ./docker/default /etc/nginx/sites-enabled/
+    COPY ./docker/disable_strict_mode.cnf /etc/mysql/conf.d/
+
+    # Copy all files from the host to the container
+    COPY ./AmpConf /var/www/rdcore/AmpConf
+    COPY ./cake4 /var/www/rdcore/cake4
+    COPY ./login /var/www/rdcore/login
+    COPY ./rd /var/www/rdcore/rd
 
     RUN mkdir -p /var/www/html
     RUN ln -s /var/www/rdcore/rd /var/www/html/rd
@@ -84,16 +89,16 @@ FROM jtreminio/php:8.1
     RUN mkdir -p /var/run/freeradius
     RUN chown freerad. /var/run/freeradius
 
-    COPY ./freeradius.service /lib/systemd/system/
+    COPY ./docker/freeradius.service /lib/systemd/system/
 
     ## cleanup
     RUN rm -rf /var/lib/apt/lists/*
 
     # supervisord allows multiple processes to be started with a single process
-    COPY ./supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+    COPY ./docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
     # Copy php settings
-    COPY ./php.ini /etc/php/php.ini
+    COPY ./docker/php.ini /etc/php/php.ini
 
     # Fix the configs to point to external database
     RUN sed  -i  "s/'host' => 'localhost'/'host' => 'rdmariadb'/g" /var/www/html/cake4/rd_cake/config/app_local.php

--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@ The recommended **Operating System** to develop and run RdCore on is **Ubuntu**
 ### Installing RdCore on Ubuntu 20.04
 *  This guide assumes you have an **Ubuntu 20.04** machine with ssh access.
 *  [Ubuntu 20.04 Installation Guide](https://github.com/RADIUSdesk/rdcore/wiki/Prepare-RdCore-on-Ubuntu-20.04)
+
+### Installing RdCore with Docker
+You can also install RdCore with Docker. This is the easiest way to get started with RdCore.
+
+- Run the following command to install RdCore with Docker:
+    ```bash
+    ./docker_build.sh
+    ```
+- After the installation is complete, you can access RdCore at http://localhost:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   radiusdesk:
     build:
       context: ./
-      dockerfile: Dockerfile-build-radiusdesk
       args:
         radiusdesk_volume: ${RADIUSDESK_VOLUME}
     container_name: radiusdesk

--- a/docker/.env
+++ b/docker/.env
@@ -1,2 +1,0 @@
-RADIUSDESK_VOLUME=/mnt/data/radiusdesk
-RADIUSDESK_NETWORK=radiusdesk-bridge

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,8 +6,3 @@ Dockerised new radiusdesk from https://github.com/RADIUSdesk based on
  - MariaDB to store the data.
  - CakePHP 4.x to create an API.
  - ExtJs 7.0 to present a modern GUI that interacts with the API.
-
-## To install just run the build script
-```
-./local_build.sh
-```

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -2,6 +2,9 @@
 
 set -xu
 
+# Set default platform to linux/amd64 (for M1 Macs)
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+
 docker network create --attachable -d bridge radiusdesk-bridge
 
 source ./.env
@@ -17,24 +20,17 @@ echo
 echo Starting Build ....
 echo
 echo Copying database files to volume mounts for MariaDB ...
-mkdir  -p /mnt/data/radiusdesk
-mkdir  -p /mnt/data/radiusdesk/db_startup
-mkdir  -p /mnt/data/radiusdesk/db_conf
-chmod -R 777 /mnt/data/radiusdesk
-chmod -R 777 /mnt/data/radiusdesk/db_startup
-chmod -R 777 /mnt/data/radiusdesk/db_conf
+mkdir  -p $RADIUSDESK_VOLUME
+mkdir  -p $RADIUSDESK_VOLUME/db_startup
+mkdir  -p $RADIUSDESK_VOLUME/db_conf
+chmod -R 777 $RADIUSDESK_VOLUME
+chmod -R 777 $RADIUSDESK_VOLUME/db_startup
+chmod -R 777 $RADIUSDESK_VOLUME/db_conf
 
-if [ -d "rdcore" ] 
-then
-    echo "Directory rdcore exists."
-else
-    git clone https://github.com/RADIUSdesk/rdcore
-fi
-
-cp rdcore/cake4/rd_cake/setup/db/rd.sql $RADIUSDESK_VOLUME/db_startup
-cp db_priveleges.sql $RADIUSDESK_VOLUME/db_startup
-cp startup.sh $RADIUSDESK_VOLUME/db_startup
-cp my_custom.cnf $RADIUSDESK_VOLUME/db_conf
+cp ./cake4/rd_cake/setup/db/rd.sql $RADIUSDESK_VOLUME/db_startup
+cp ./docker/db_priveleges.sql $RADIUSDESK_VOLUME/db_startup
+cp ./docker/startup.sh $RADIUSDESK_VOLUME/db_startup
+cp ./docker/my_custom.cnf $RADIUSDESK_VOLUME/db_conf
 
 echo 
 echo Building docker database container ...


### PR DESCRIPTION
This PR is to tidy up the docker files and make them easier to maintain.
The previous docker setup makes duplicate copies of the code and is not easy to maintain.

This PR will:
- Move the `docker-compose` files to the root of the project
- rename the `Dockerfile-build-radiusdesk` to `Dockerfile` and move it to the root of the project
- rename the l`ocal_build.sh` to `docker_build.sh` and move it to the root of the project
- update the `docker_build.sh` to match with the new project structure

Testing
- [x] Run the docker_build.sh script
- [x] Access the radiusdesk web interface